### PR TITLE
Update logger to use file handles

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 - macOS: Point the user to the OS' please-enable-notification prompt #474 
 - Improve error alerts #489
 - Update WireGuardKit to fix crash in tunnel
+- Update logger to use file handles to fix crash in tunnel
 
 ## 3.0.6
 

--- a/EduVPN.xcodeproj/project.pbxproj
+++ b/EduVPN.xcodeproj/project.pbxproj
@@ -30,6 +30,8 @@
 		6F13E3E124977BA800E21614 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C7DB4C6B248064BC009932B1 /* Main.storyboard */; };
 		6F13E3E424977C1300E21614 /* config.json in Resources */ = {isa = PBXBuildFile; fileRef = C7DB4C1A24805F9B009932B1 /* config.json */; };
 		6F1A1C0124EE8EDB0040D6A2 /* SupportContactTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F1A1C0024EE8EDB0040D6A2 /* SupportContactTextView.swift */; };
+		6F215BB52A160475003D3B60 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F21F40926899B7A00C157E1 /* Logger.swift */; };
+		6F215BB62A160477003D3B60 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F21F40926899B7A00C157E1 /* Logger.swift */; };
 		6F21F40A26899B7A00C157E1 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F21F40926899B7A00C157E1 /* Logger.swift */; };
 		6F21F40B26899B7A00C157E1 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F21F40926899B7A00C157E1 /* Logger.swift */; };
 		6F25F8D2269D763F00FA8FAB /* ConnectionViewController+macOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F25F8D1269D763F00FA8FAB /* ConnectionViewController+macOS.swift */; };
@@ -1865,6 +1867,7 @@
 				6F57338724CD1570008912D4 /* SessionExpiryHelper.swift in Sources */,
 				6F7B63F02500FD7300FB154A /* StatusItemController.swift in Sources */,
 				6F7B63F225022AAE00FB154A /* LaunchAtLoginHelper.swift in Sources */,
+				6F215BB52A160475003D3B60 /* Logger.swift in Sources */,
 				C7DB4BA2247FC243009932B1 /* SearchViewModel.swift in Sources */,
 				C7DB4BD524803B99009932B1 /* SignatureHelper.swift in Sources */,
 				C7DB4B6B247FC198009932B1 /* AppDelegate.swift in Sources */,
@@ -1954,6 +1957,7 @@
 				6F116CAF25345D0300C73797 /* ConnectionService.swift in Sources */,
 				6F30735A2689B8110083EEEF /* Shared.swift in Sources */,
 				6F5E6C422522E9B9000225C0 /* PersistenceService.swift in Sources */,
+				6F215BB62A160477003D3B60 /* Logger.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/EduVPN/Services/LoggingService.swift
+++ b/EduVPN/Services/LoggingService.swift
@@ -9,96 +9,51 @@ import PromiseKit
 
 class LoggingService {
 
-    private let logFileURL: URL? = {
-        let appGroup: String = {
-            let appBundleId = Bundle.main.bundleIdentifier ?? ""
-            #if os(macOS)
-            return "\((Bundle.main.infoDictionary?["AppIdentifierPrefix"] as? String) ?? "")group.\(appBundleId)"
-            #elseif os(iOS)
-            return "group.\(appBundleId)"
-            #endif
-        }()
-        let appGroupURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroup)
-        return appGroupURL?.appendingPathComponent("debug.log")
-    }()
-    private let maxLogLines = 1000
-
-    private var logLines: [String]
-    private let dateFormatter: DateFormatter
     private var logSeparator = "--- EOF ---"
     private var appLogStarter = "App:"
     private var tunnelLogStarter = "Tunnel:"
+    private var logger: Logger?
 
     private let connectionService: ConnectionService
 
     init(connectionService: ConnectionService) {
         self.connectionService = connectionService
-        self.logLines = []
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
-        self.dateFormatter = dateFormatter
     }
 
-    func appLog(_ message: String, printToConsole: Bool = true) {
-        let timestamp = dateFormatter.string(from: Date())
-        let line = "\(timestamp) \(message)"
-        if printToConsole {
-            NSLog(message)
-        }
-        if logLines.count >= maxLogLines {
-            logLines.removeFirst()
-        }
-        if logLines.isEmpty {
-            logLines.append(appLogStarter)
-        }
-        logLines.append(line)
+    func appLog(_ message: String) {
+        getLogger().log(message)
     }
 
-    func logAppVersion() {
-        var appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown version"
-        if let appBuild = Bundle.main.infoDictionary?["CFBundleVersion"] as? String {
-            appVersion += " (\(appBuild))"
-        }
-        appLog("App version: \(appVersion)", printToConsole: false)
-    }
-
-    func flushLogToDisk() {
-        appLog("Flushing app log to disk ...")
-
-        if let url = logFileURL {
-            let content = logLines.joined(separator: "\n")
-            let data = content.data(using: .utf8)
-            if FileManager.default.fileExists(atPath: url.path) {
-                do {
-                    let fileHandle = try FileHandle(forWritingTo: url)
-                    if let data = data {
-                        fileHandle.seekToEndOfFile()
-                        if let newLines = "\n\n".data(using: .utf8) {
-                            fileHandle.write(newLines)
-                        }
-                        fileHandle.write(data)
-                        fileHandle.closeFile()
-                    }
-                } catch {
-                    NSLog("Error appending app log to disk: \(error)")
-                }
-            } else {
-                do {
-                    try content.write(to: url, atomically: true, encoding: .utf8)
-                } catch {
-                    NSLog("Error creating app log on disk: \(error)")
-                }
-            }
-            logLines = []
-        }
+    func closeLogFile() {
+        getLogger().log(Logger.endOfAppLogMarker)
+        self.logger = nil
     }
 
     func getLog() -> Promise<String?> {
-        firstly {
-            connectionService.getConnectionLog()
-        }.map { [weak self] logContent in
-            guard let self = self else { return nil }
-            return (logContent ?? "") + self.logLines.joined(separator: "\n")
+        return connectionService.getConnectionLog()
+    }
+
+    private func getLogger() -> Logger {
+        if let logger = self.logger {
+            return logger
+        } else {
+            let appGroup: String = {
+                let appBundleId = Bundle.main.bundleIdentifier ?? ""
+                #if os(macOS)
+                return "\((Bundle.main.infoDictionary?["AppIdentifierPrefix"] as? String) ?? "")group.\(appBundleId)"
+                #elseif os(iOS)
+                return "group.\(appBundleId)"
+                #endif
+            }()
+            let logContainerDirectoryURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroup)!
+            let logFileURL = logContainerDirectoryURL.appendingPathComponent("debug.log")
+            let tempLogFileURL = logContainerDirectoryURL.appendingPathComponent("temp.log")
+            let logger = Logger(appComponent: .containerApp, logFileURL: logFileURL, tempFileURL: tempLogFileURL,
+                                shouldTruncateTillLogSeparator: false,
+                                canAppendLogSeparatorOnInit: true)
+            logger.logAppVersion()
+            self.logger = logger
+            return logger
         }
     }
 }

--- a/Shared/Logger.swift
+++ b/Shared/Logger.swift
@@ -5,79 +5,82 @@
 //  Copyright © 2021 The Commons Conservancy. All rights reserved.
 
 import Foundation
-
+import os.log
 class Logger {
-    let maxLinesInMemory = 1000
 
-    let logFileURL: URL?
-
-    private(set) var lines: [String]
-    private let dateFormatter: DateFormatter
-
-    init(appGroup: String, logSeparator: String, isStartedByApp: Bool, logFileName: String) {
-        let parentURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroup)
-        let url = parentURL?.appendingPathComponent(logFileName)
-        self.logFileURL = url
-        if let url = url {
-            var existingLog = (try? String(contentsOf: url))?.components(separatedBy: "\n") ?? []
-            if let index = existingLog.firstIndex(of: logSeparator) {
-                existingLog.removeFirst(index + 2)
-            }
-            if isStartedByApp,
-               let appLogStartIndex = Self.indexOfTrailingAppLog(
-                    in: existingLog, appSeparator: "App:", otherSeparators: ["Tunnel:", logSeparator]) {
-                if appLogStartIndex > 0 {
-                    existingLog.insert(contentsOf: [logSeparator, ""], at: appLogStartIndex)
-                }
-                existingLog.append("")
-                existingLog.append("Tunnel:")
-            } else if !existingLog.isEmpty {
-                existingLog.append("")
-                existingLog.append(logSeparator)
-                existingLog.append("")
-            }
-            lines = existingLog
-        } else {
-            lines = []
-        }
-
-        dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
+    enum AppComponent: String {
+        case containerApp = "APP"
+        case tunnelExtension = "TUN"
     }
 
-    private static func indexOfTrailingAppLog(in lines: [String], appSeparator: String, otherSeparators: [String]) -> Int? {
-        for index in stride(from: lines.count - 1, through: 0, by: -1) {
-            let line = lines[index]
-            if line == appSeparator {
-                return index
-            }
-            if otherSeparators.contains(line) {
-                return nil
-            }
+    static let logSeparator = "--- EOF ---"
+    static let endOfAppLogMarker = "End of app log"
+
+    private let logFileURL: URL?
+    private var logFileHandle: UnsafeMutablePointer<FILE>?
+    private let dateFormatter: DateFormatter
+    private let osLog: OSLog
+    private var timer: DispatchSourceTimer?
+    private var timerQueue: DispatchQueue
+    private var fileQueue: DispatchQueue
+    private var shouldWriteLogSeparatorBeforeNextLogEntry = false
+
+    init(appComponent: Logger.AppComponent, logFileURL: URL, tempFileURL: URL, shouldTruncateTillLogSeparator: Bool, canAppendLogSeparatorOnInit: Bool) {
+        self.logFileURL = logFileURL
+
+        let appId = Bundle.main.bundleIdentifier ?? ""
+        let osLog = OSLog(subsystem: appId, category: appComponent.rawValue)
+        let timerQueue = DispatchQueue(label: "LoggerTimerQueue", qos: .background)
+        let fileQueue = DispatchQueue(label: "LoggerFileQueue", qos: .background)
+
+        if let (fileHandle, shouldAddLogSeparator) = Self.setup(osLog: osLog, fileQueue: fileQueue, logFileURL: logFileURL, tempFileURL: tempFileURL,
+                                       shouldTruncateTillLogSeparator: shouldTruncateTillLogSeparator,
+                                       canAppendLogSeparatorOnInit: canAppendLogSeparatorOnInit) {
+            self.logFileHandle = fileHandle
+            self.shouldWriteLogSeparatorBeforeNextLogEntry = shouldAddLogSeparator
+            os_log("Writing log to file: %{public}@", log: osLog, logFileURL.path)
+        } else {
+            self.logFileHandle = nil
+            os_log("Not writing log to file")
         }
-        return nil
+
+        self.dateFormatter = DateFormatter()
+        self.dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
+        self.osLog = osLog
+        self.timerQueue = timerQueue
+        self.fileQueue = fileQueue
     }
 
     func log(_ message: String) {
-        let timestamp = dateFormatter.string(from: Date())
-        let line = "\(timestamp) \(message)"
-        NSLog("\(line)\n")
-        if lines.count >= maxLinesInMemory {
-            lines.removeFirst()
+        guard let logFileHandle = self.logFileHandle else {
+            return
         }
-        lines.append(line)
+
+        let timestamp = dateFormatter.string(from: Date())
+        let line = "\(timestamp) \(message)\n"
+        self.write(line, to: logFileHandle, osLog: self.osLog)
+
+        os_log("%{public}@", log: self.osLog, message)
+
+        // Flush to disk every 5 seconds
+        if self.timer == nil {
+            // We don't use an NSTimer here because:
+            // https://developer.apple.com/forums/thread/687170
+            let timer = DispatchSource.makeTimerSource(queue: self.timerQueue)
+            timer.schedule(deadline: .now() + .seconds(5), leeway: .seconds(1))
+            timer.setEventHandler { [weak self] in
+                guard let self = self else { return }
+                self.flush(logFileHandle)
+                self.timer = nil
+            }
+            timer.resume()
+            self.timer = timer
+        }
     }
 
-    func flushToDisk() {
-        log("Flushing log ...")
-        if let url = logFileURL {
-            let content = lines.joined(separator: "\n")
-            do {
-                try content.write(to: url, atomically: true, encoding: .utf8)
-            } catch {
-                NSLog("Error writing WireGuard log to disk: \(error)")
-            }
-            lines = []
+    func flush() {
+        if let logFileHandle = self.logFileHandle {
+            self.flush(logFileHandle)
         }
     }
 
@@ -87,5 +90,205 @@ class Logger {
             appVersion += " (\(appBuild))"
         }
         log("App version: \(appVersion)")
+        flush()
+    }
+
+    func getLines(completionHandler: @escaping ([String]) -> Void) {
+        var lines: [String] = []
+        if let logFilePath = self.logFileURL?.path {
+            self.fileQueue.async {
+                let logFileHandle = fopen(logFilePath, "r")
+
+                var bufferPointer: UnsafeMutablePointer<CChar>?
+                var bufferSize: Int = 0
+                var bytesRead = 0
+
+                repeat {
+                    bytesRead = getline(&bufferPointer, &bufferSize, logFileHandle)
+                    if bytesRead > 0, let bufferPointer = bufferPointer {
+                        let line = String(cString: bufferPointer)
+                        lines.append(line)
+                    }
+                } while (bytesRead > 0)
+
+                completionHandler(lines)
+            }
+        } else {
+            completionHandler([])
+        }
+    }
+
+    deinit {
+        if let logFileHandle = self.logFileHandle {
+            log("Closing log file")
+            self.close(logFileHandle)
+        }
+    }
+}
+
+private extension Logger {
+    static func setup(osLog: OSLog, fileQueue: DispatchQueue, logFileURL: URL, tempFileURL: URL,
+                      shouldTruncateTillLogSeparator: Bool,
+                      canAppendLogSeparatorOnInit: Bool) -> (UnsafeMutablePointer<FILE>, Bool)? {
+        var hasPreExistingLogEntries = false
+        var lastTwoLines: [String] = []
+        let fileManager = FileManager.default
+        if fileManager.fileExists(atPath: logFileURL.path) {
+            if shouldTruncateTillLogSeparator {
+                (hasPreExistingLogEntries, lastTwoLines) = Self.truncateEarlyLogEntries(logFileURL: logFileURL, tempFileURL: tempFileURL, osLog: osLog)
+            } else {
+                (hasPreExistingLogEntries, lastTwoLines) = Self.detectExistingLogEntries(logFileURL: logFileURL)
+            }
+        }
+        guard let fileHandle = fopen(logFileURL.path, "a") else {
+            return nil
+        }
+        let hasEndOfAppLogMarker = lastTwoLines.contains(where: { $0.hasSuffix(Self.endOfAppLogMarker) })
+        let shouldAddLogSeparator = hasPreExistingLogEntries && !hasEndOfAppLogMarker && canAppendLogSeparatorOnInit
+        return (fileHandle, shouldAddLogSeparator)
+    }
+
+    static func write(_ message: String, to fileHandle: UnsafeMutablePointer<FILE>, osLog: OSLog, fileQueue: DispatchQueue) {
+        if let cString = message.cString(using: .utf8) {
+            let result = cString.withUnsafeBufferPointer { cStringPointer in
+                fileQueue.sync {
+                    fputs(cStringPointer.baseAddress, fileHandle)
+                }
+            }
+            if result <= 0 {
+                os_log("Error writing log message to file", log: osLog)
+            }
+        }
+    }
+
+    func write(_ message: String, to fileHandle: UnsafeMutablePointer<FILE>, osLog: OSLog) {
+        if shouldWriteLogSeparatorBeforeNextLogEntry {
+            os_log("Adding log separator to file", log: osLog)
+            Self.write("\n\(Self.logSeparator)\n\n", to: fileHandle, osLog: osLog, fileQueue: fileQueue)
+            shouldWriteLogSeparatorBeforeNextLogEntry = false
+        }
+        Self.write(message, to: fileHandle, osLog: osLog, fileQueue: self.fileQueue)
+    }
+
+    func close(_ fileHandle: UnsafeMutablePointer<FILE>) {
+        _ = self.fileQueue.sync {
+            fclose(fileHandle)
+        }
+    }
+
+    func flush(_ fileHandle: UnsafeMutablePointer<FILE>) {
+        _ = self.fileQueue.sync {
+            fflush(fileHandle)
+        }
+    }
+
+    @discardableResult
+    static func truncateEarlyLogEntries(logFileURL: URL, tempFileURL: URL, osLog: OSLog) -> (Bool, [String]) {
+        var tempFileHandle: UnsafeMutablePointer<FILE>?
+        let logFileHandle = fopen(logFileURL.path, "r")
+
+        var bufferPointer: UnsafeMutablePointer<CChar>?
+        var bufferSize: Int = 0
+
+        var bytesRead = 0
+        var isLogSeparatorFound = false
+        var isSkippingEmptyLinesSequence = false
+        var tmpFileHasLogEntries = false
+        var origFileHasLogEntries = false
+        var lastTwoLines: [String] = []
+
+        repeat {
+            bytesRead = getline(&bufferPointer, &bufferSize, logFileHandle)
+            if bytesRead > 0, let bufferPointer = bufferPointer {
+                let line = String(cString: bufferPointer)
+
+                let isEmptyLine = (line == "\n")
+                if !isEmptyLine {
+                    origFileHasLogEntries = true
+                }
+                if isSkippingEmptyLinesSequence {
+                    if isEmptyLine {
+                        continue
+                    } else {
+                        isSkippingEmptyLinesSequence = false
+                    }
+                }
+                if isLogSeparatorFound {
+                    if let tmpFileHandle = tempFileHandle {
+                        fwrite(bufferPointer, bytesRead, 1, tmpFileHandle)
+                        tmpFileHasLogEntries = true
+                    }
+                } else if line.hasPrefix(Self.logSeparator) {
+                    isLogSeparatorFound = true
+                    isSkippingEmptyLinesSequence = true
+                    if tempFileHandle == nil {
+                        tempFileHandle = fopen(tempFileURL.path, "w")
+                    }
+                }
+
+                if lastTwoLines.count > 1 {
+                    lastTwoLines.removeFirst(lastTwoLines.count - 1)
+                }
+                lastTwoLines.append(line)
+            }
+        } while (bytesRead > 0)
+
+        if let logFileHandle = logFileHandle {
+            fclose(logFileHandle)
+        }
+        if let tmpFileHandle = tempFileHandle {
+            fclose(tmpFileHandle)
+        }
+        bufferPointer?.deallocate()
+
+        if isLogSeparatorFound {
+            os_log("Truncating log", log: osLog)
+            let fileManager = FileManager.default
+            do {
+                try fileManager.removeItem(at: logFileURL)
+            } catch {
+                os_log("Error removing log at \"%{public}@\": %{public}@", log: osLog, logFileURL.path, error.localizedDescription)
+                return (origFileHasLogEntries, lastTwoLines)
+            }
+            do {
+                try fileManager.moveItem(at: tempFileURL, to: logFileURL)
+            } catch {
+                os_log("Error moving log at \"%{public}@\" to \"%{public}@\": %{public}@", log: osLog, tempFileURL.path, logFileURL.path, error.localizedDescription)
+                return (false, lastTwoLines)
+            }
+            return (tmpFileHasLogEntries, lastTwoLines)
+        } else {
+            os_log("Not truncating log", log: osLog, logFileURL.path)
+            return (origFileHasLogEntries, lastTwoLines)
+        }
+    }
+
+    static func detectExistingLogEntries(logFileURL: URL) -> (Bool, [String]) {
+        let logFileHandle = fopen(logFileURL.path, "r")
+
+        var bufferPointer: UnsafeMutablePointer<CChar>?
+        var bufferSize: Int = 0
+
+        var bytesRead = 0
+        var origFileHasLogEntries = false
+        var lastTwoLines: [String] = []
+
+        repeat {
+            bytesRead = getline(&bufferPointer, &bufferSize, logFileHandle)
+            if bytesRead > 0, let bufferPointer = bufferPointer {
+                let line = String(cString: bufferPointer)
+
+                let isEmptyLine = (line == "\n")
+                if !isEmptyLine {
+                    origFileHasLogEntries = true
+                    if lastTwoLines.count > 1 {
+                        lastTwoLines.removeFirst(lastTwoLines.count - 1)
+                    }
+                    lastTwoLines.append(line)
+                }
+            }
+        } while (bytesRead > 0)
+
+        return (origFileHasLogEntries, lastTwoLines)
     }
 }

--- a/Shared/Shared.swift
+++ b/Shared/Shared.swift
@@ -16,7 +16,7 @@ enum VPNProtocol: String {
 enum TunnelMessageCode: UInt8 {
     case getTransferredByteCount = 0 // Returns TransferredByteCount as Data
     case getNetworkAddresses = 1 // Returns [String] as JSON
-    case getLog = 2 // Returns UTF-8 string
+    case flushLog = 2 // Returns empty Data()
     case getConnectedDate = 3 // Returns UInt64 as Data
 
     var data: Data { Data([rawValue]) }

--- a/TunnelExtension/OpenVPN/OpenVPNAdapterInterface.swift
+++ b/TunnelExtension/OpenVPN/OpenVPNAdapterInterface.swift
@@ -76,7 +76,7 @@ class OpenVPNAdapterInterface: TunnelAdapterInterface {
 
         let adapter = OpenVPNAdapter(with: packetTunnelProvider)
 
-        adapter.flushLogHandler = { [weak self] in self?.logger.flushToDisk() }
+        adapter.flushLogHandler = { [weak self] in self?.logger.flush() }
 
         if !options.isStartedByApp {
             adapter.authFailShutdownHandler = { [weak packetTunnelProvider] in

--- a/TunnelExtension/PacketTunnelProvider.swift
+++ b/TunnelExtension/PacketTunnelProvider.swift
@@ -174,13 +174,11 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             }
             let encoder = JSONEncoder()
             completionHandler?(try? encoder.encode(addresses))
-        case .getLog:
-            var data = Data()
-            /*for line in (logger?.lines ?? []) {
-                data.append(line.data(using: .utf8) ?? Data())
-                data.append("\n".data(using: .utf8) ?? Data())
-            }*/
-            completionHandler?(data)
+        case .flushLog:
+            if let logger = logger {
+                logger.flush()
+            }
+            completionHandler?(nil)
         case .getConnectedDate:
             completionHandler?(connectedDate?.toData())
         }

--- a/TunnelExtension/PacketTunnelProvider.swift
+++ b/TunnelExtension/PacketTunnelProvider.swift
@@ -178,7 +178,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             if let logger = logger {
                 logger.flush()
             }
-            completionHandler?(nil)
+            completionHandler?(Data())
         case .getConnectedDate:
             completionHandler?(connectedDate?.toData())
         }

--- a/TunnelExtension/PacketTunnelProvider.swift
+++ b/TunnelExtension/PacketTunnelProvider.swift
@@ -8,6 +8,7 @@
 import NetworkExtension
 
 enum PacketTunnelProviderError: Error {
+    case unableToGetSharedLogLocation
     case savedProtocolConfigurationIsInvalid
     case adapterError(Error)
 
@@ -71,10 +72,17 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         }
 #endif
 
-        let logger = Logger(appGroup: appGroup,
-                            logSeparator: "--- EOF ---",
-                            isStartedByApp: startTunnelOptions.isStartedByApp,
-                            logFileName: "debug.log")
+        guard let parentURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroup) else {
+            completionHandler(PacketTunnelProviderError.unableToGetSharedLogLocation)
+            return
+        }
+        let logFileURL = parentURL.appendingPathComponent("debug.log")
+        let tempLogFileURL = parentURL.appendingPathComponent("temp.log")
+        let logger = Logger(appComponent: .tunnelExtension,
+                            logFileURL: logFileURL,
+                            tempFileURL: tempLogFileURL,
+                            shouldTruncateTillLogSeparator: true,
+                            canAppendLogSeparatorOnInit: !startTunnelOptions.isStartedByApp)
         logger.logAppVersion()
         self.logger = logger
 
@@ -130,7 +138,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             if let error = error {
                 NSLog("Failed to stop adapter: \(error.localizedDescription)")
             }
-            self.logger?.flushToDisk()
+            self.logger?.flush()
             completionHandler()
 
             #if os(macOS)
@@ -168,10 +176,10 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             completionHandler?(try? encoder.encode(addresses))
         case .getLog:
             var data = Data()
-            for line in (logger?.lines ?? []) {
+            /*for line in (logger?.lines ?? []) {
                 data.append(line.data(using: .utf8) ?? Data())
                 data.append("\n".data(using: .utf8) ?? Data())
-            }
+            }*/
             completionHandler?(data)
         case .getConnectedDate:
             completionHandler?(connectedDate?.toData())


### PR DESCRIPTION
Revamped Logger:
- Logging operations directly write to a file on disk, so no log entries are discarded because of "too many lines in memory"
- File writes / flushes are queued to avoid crashes / races
